### PR TITLE
Add `Available()` to return whether Rosetta is installed

### DIFF
--- a/rosetta.go
+++ b/rosetta.go
@@ -1,11 +1,19 @@
+//go:build darwin
 // +build darwin
 
 package rosetta
 
 import (
+	"os"
 	"runtime"
 	"syscall"
 )
+
+// Available returns true if Rosetta is installed/available
+func Available() bool {
+	_, err := os.Stat("/Library/Apple/usr/share/rosetta")
+	return err == nil
+}
 
 // Enabled returns true if running in a Rosetta Translated Binary, false otherwise.
 func Enabled() bool {

--- a/rosetta_unsupported.go
+++ b/rosetta_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !darwin
 // +build !darwin
 
 package rosetta
@@ -5,6 +6,11 @@ package rosetta
 import (
 	"runtime"
 )
+
+// Available returns true if Rosetta is installed/available
+func Available() bool {
+	return false
+}
 
 // Enabled returns true if running in a Rosetta Translated Binary, false otherwise.
 func Enabled() bool {


### PR DESCRIPTION
Adds `Available()` to check whether Rosetta is installed.

Other ways to achieve this are checking for the running `oahd` process and checking the exit code of `pkgutil --pkg-info="com.apple.pkg.RosettaUpdateAuto"`, but both of these require spawning another process so this implementation seemed superior

Signed-off-by: Laura Brehm <laurabrehm@hey.com>